### PR TITLE
Add NotFair under Marketing AI Tools / Advertising

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[NotFair](https://notfair.co/)** - Hosted Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.
 
 
 ### Phone Calls

--- a/marketing.md
+++ b/marketing.md
@@ -53,6 +53,7 @@ A curated list of AI tools designed to enhance marketing strategies, automate ta
 - **[Adzooma](https://www.adzooma.com/)** - Automates PPC campaign management across Google, Microsoft, and Facebook Ads platforms with AI insights.
 - **[Albert AI](https://albert.ai/)** - Fully autonomous AI-driven platform for managing cross-channel digital advertising campaigns.
 - **[AdEspresso](https://adespresso.com/)** - AI-based optimization tool for managing and scaling Facebook and Google ad campaigns.
+- **[NotFair](https://notfair.co/)** - Hosted Google Ads MCP server that connects Claude and other AI agents to a Google Ads account; diagnose campaign performance, recommend bid/budget/keyword optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate.
 
 ## Analytics
 


### PR DESCRIPTION
Adding NotFair to the Marketing AI Tools section in README.md and the Advertising section in marketing.md.

NotFair is a hosted Google Ads MCP server that lets Claude and other AI agents (Cursor, etc.) connect to a Google Ads account to diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API. There's a built-in human-approval gate before anything writes to the account.

Linked to the product page since there's no public source repo, similar to other entries in these sections (Jasper AI, Adzooma, Albert AI, etc.).

Happy to adjust the wording or move the entry if you'd prefer.