### PR TITLE
Add NotFair — open-source SEO & paid-ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[NotFair](https://github.com/nowork-studio/NotFair)** - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; powered by Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 
 ### Phone Calls

--- a/marketing.md
+++ b/marketing.md
@@ -53,6 +53,7 @@ A curated list of AI tools designed to enhance marketing strategies, automate ta
 - **[Adzooma](https://www.adzooma.com/)** - Automates PPC campaign management across Google, Microsoft, and Facebook Ads platforms with AI insights.
 - **[Albert AI](https://albert.ai/)** - Fully autonomous AI-driven platform for managing cross-channel digital advertising campaigns.
 - **[AdEspresso](https://adespresso.com/)** - AI-based optimization tool for managing and scaling Facebook and Google ad campaigns.
+- **[NotFair](https://github.com/nowork-studio/NotFair)** - Open-source Claude Code skills for Google Ads and Meta Ads; connects live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, surface wasted spend, and manage keywords and bids.
 
 ## Analytics
 


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** NotFair
- **Description:** Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads.
- **Tool URL:** https://github.com/nowork-studio/NotFair
- **Altern.ai page link:** N/A

## 📌 Description

Hi, thank you for maintaining this list — it's a genuinely useful resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), a MIT-licensed open-source project (~2.9k stars) that provides a set of Claude Code agent skills for marketing and advertising work.

It connects to live account data through four MCPs: **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**. The skill areas cover Google Ads audits and keyword management, Meta (Facebook + Instagram) Ads creative and audience analysis, and SEO/GEO tools like site analysis, keyword research, meta tag optimization, and schema markup.

I've added it to the Advertising section in `marketing.md` and the Marketing AI Tools section in `README.md`, matching the format of existing entries. Happy to reword, move to a different section, or trim to just one file if you prefer.

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool